### PR TITLE
Fix Array to string conversion warning in Gutenberg block data handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 Icon?
 ehthumbs.db
 Thumbs.db
+package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.5.3]
+
+#### Bug
+
+- Fix "Array to string conversion" warning in Gutenberg block data handling
+
 ## [1.5.2]
 
 #### Fixes

--- a/business-profile-render.php
+++ b/business-profile-render.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Business Profile Render
 Description: Tool to provide utilities for displaying synchronized business profile data
-Version: 1.5.2
+Version: 1.5.3
 Author: Website Pro Team
 License: GPL v2 or later
 */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "business-profile-render",
-    "version": "1.5.2",
+    "version": "1.5.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "business-profile-render",
-            "version": "1.5.2",
+            "version": "1.5.3",
             "license": "GPL-2.0-or-later",
             "devDependencies": {
                 "@wordpress/scripts": "27.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "business-profile-render",
-    "version": "1.5.2",
+    "version": "1.5.3",
     "description": "Tool to provide utilities for displaying synchronized business profile data",
     "main": "assets/js/gutenberg-block.js",
     "scripts": {

--- a/src/Blocks/GutenbergBlock.php
+++ b/src/Blocks/GutenbergBlock.php
@@ -45,33 +45,26 @@ class GutenbergBlock {
     public static function preprocess_business_profile_data($data) {
         $processed_data = array();
 
-        $processed_data[''] = '';
-    
-        // Loop through each key-value pair in the data
         foreach ($data as $key => $value) {
-    
             // Capitalize each word in the key
             $processed_key = ucwords(str_replace('_', ' ', $key));
-    
-            // If the value is empty, set it to "No data available"
-            if (empty($value)) {
+
+            // Handle different value types properly
+            if ($value === '' || $value === null) {
                 $processed_value = __("No data available", 'business-profile-render');
+            } elseif (is_array($value)) {
+                $processed_value = implode(', ', array_map('sanitize_text_field', $value));
             } else {
-                // If the value is an array, implode it with ","
-                if (is_array($value)) {
-                    $processed_value = implode(', ', $value);
-                } else {
-                    $processed_value = $value;
-                }
+                $processed_value = sanitize_text_field((string) $value);
             }
-    
-            // Add processed key-value pair to the processed data array
+
+            // Store processed key-value pair
             $processed_data[$processed_key] = $processed_value;
         }
-    
-        return $processed_data;
-    }    
 
+        return $processed_data;
+    }
+        
 }
 
 GutenbergBlock::init();


### PR DESCRIPTION
Problems : 

- PHP Warning: "Array to string conversion" in GutenbergBlock.php.
- Caused by directly assigning array values instead of converting them.

Solution : 
- Validated $business_profile_data to ensure it's an array.
- Properly handled arrays using implode().





Jira Case : https://vendasta.jira.com/browse/WSP-2083

@vplugins/websitepro 